### PR TITLE
fix(windows): Use app.exit to clean up the tray

### DIFF
--- a/src/platform_impl/windows.rs
+++ b/src/platform_impl/windows.rs
@@ -64,7 +64,7 @@ pub fn init<R: Runtime>(f: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
                             lpData: bytes.as_ptr() as _,
                         };
                         SendMessageW(hwnd, WM_COPYDATA, 0, &cds as *const _ as _);
-                        std::process::exit(0);
+                        app.exit(0);
                     }
                 }
             } else {


### PR DESCRIPTION
This way the tray icon still flashes, but at least it doesn't stay until the user moves the mouse on it.